### PR TITLE
add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+**Expected behaviour:**
+
+
+**Actual behaviour:**
+
+
+---
+ - Python version[s]:
+
+Do not forget to label the issue properly and asign it to a milestone if necessary 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Fixes #
+Changes made in this Pull Request:
+
+
+--- 
+Before creating the PR, have you ... ?:
+ - [ ] Created/updated docs
+ - [ ] Created/updated tests (and run them locally)
+ - [ ] Updated `requirements.txt` if a new package was installed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Fixes #
-Changes made in this Pull Request:
+**Changes made in this Pull Request:**
 
 
 --- 


### PR DESCRIPTION
**Changes made in this Pull Request:**
Added templates for issues and pull requests, see [here](https://github.com/blog/2111-issue-and-pull-request-templates). 
These templates need to be in the master branch in order to be used by Github. Maybe we can merge this branch into master (so we can start using them) and then master into develop (so develop is not behind master)?

--- 
Before creating the PR, have you ... ?:
 - [x] Created/updated docs.
 - [x] Created/updated tests (and run them locally)
 - [x] Updated `requirements.txt` if a new package was installed