### PR TITLE
Encode dependencies in setup.py, and add matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-numpy>=1.13.1
-scikit-learn>=0.18.0
-scipy>=0.19.0
-pandas>=0.20.3
+.

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, , !=3.5.*',
     install_requires=[
+        'matplotlib',
         'numpy>=1.13.1',
         'scikit-learn>=0.18.0',
         'scipy>=0.19.0',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,11 @@ setup(
             ],
     
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, , !=3.5.*',
-
+    install_requires=[
+        'numpy>=1.13.1',
+        'scikit-learn>=0.18.0',
+        'scipy>=0.19.0',
+        'pandas>=0.20.3'
+    ]
 )
 


### PR DESCRIPTION
Fixes #
**Changes made in this Pull Request:**

Encode dependencies in `install_requires` in `setup.py`, instead of only in `requirements.txt`.

Add a dependency on `matplotlib`, since `cro.report` uses it.

--- 
Before creating the PR, have you ... ?:
 - [ ] Created/updated docs **N/A**
 - [ ] Created/updated tests (and run them locally) **N/A**
 - [ ] Updated `requirements.txt` if a new package was installed **N/A**
