### PR TITLE
Do not install “examples” as a top-level package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include cro/assets/data/voice.csv
+graft examples

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     version=_version,
     author='CRO Team',
     author_email='cro_developers@googlegroups.com',
-    packages= ['cro', 'examples'],
+    packages= ['cro'],
     url='https://github.com/VictorPelaez/coral-reef-optimization-algorithm',
     license = 'MIT',
     description='Coral Reef Optimization (CRO) Algorithm',


### PR DESCRIPTION
**Changes made in this Pull Request:**

Stop installing “`examples`” directly to `site-packages`.

Adjust `MANIFEST.in` so that the examples are still in the source distribution.

--- 
Before creating the PR, have you ... ?:
 - [ ] Created/updated docs **N/A**
 - [ ] Created/updated tests (and run them locally) **N/A**
 - [ ] Updated `requirements.txt` if a new package was installed **N/A**