### PR TITLE
Add LICENSE.txt to metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license_files = LICENSE.txt


### PR DESCRIPTION
This ensures it is included in future PyPI distributions.

**Changes made in this Pull Request:**

Source distributions and wheels will now include a copy of `LICENSE.txt` in their egg-info. This allows people to satisfy the MIT license’s requirement to include the original text and copyright notice in derivative works.

--- 
Before creating the PR, have you ... ?:
 - [ ] Created/updated docs **N/A**
 - [ ] Created/updated tests (and run them locally) **N/A**
 - [ ] Updated `requirements.txt` if a new package was installed **N/A**
