### PR TITLE
Import Bunch from sklearn.utils

### DIFF
--- a/cro/utils.py
+++ b/cro/utils.py
@@ -3,7 +3,7 @@ from inspect import getmembers, isfunction
 
 import pandas as pd
 import numpy as np
-from sklearn import datasets
+from sklearn.utils import Bunch
 
 # https://www.kaggle.com/adhok93/feature-importance-and-pca
 
@@ -21,7 +21,7 @@ def load_data(name):
     X = np.c_[np.array(data[feature_cols]), random_state.randn(data.shape[0], noisy_features)]
     feature_cols = feature_cols + noisy_features*['noise']
     
-    dataset = datasets.base.Bunch(data= X, target=np.array(data.label), feature_names=feature_cols)
+    dataset = Bunch(data= X, target=np.array(data.label), feature_names=feature_cols)
     return dataset
 
 def get_module_functions(module_name):


### PR DESCRIPTION
In current versions of scikit-learn, `sklearn.datasets.base.Bunch` is no longer present. (It is at `sklearn.datasets._base.Bunch` to emphasize that this is not a public API.)

Import the same class from the documented public API in `sklearn.utils` instead, fixing compatibility with recent scikit-learn versions.

Fixes #62 
**Changes made in this Pull Request:**

In `cro.utils`, import `Bunch` from `sklearn.utils` instead of `sklearn.datasets.base`.

--- 
Before creating the PR, have you ... ?:
 - [ ] Created/updated docs **N/A**
 - [ ] Created/updated tests (and run them locally) **N/A**
 - [ ] Updated `requirements.txt` if a new package was installed **N/A**
