### PR TITLE
Add the license file to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE.txt
 include cro/assets/data/voice.csv
 graft examples


### PR DESCRIPTION
Without this, LICENSE.txt does not appear in the sdist.

Fixes #71
**Changes made in this Pull Request:**

Add the license file to MANIFEST.in.

--- 
Before creating the PR, have you ... ?:
 - [ ] Created/updated docs **N/A***
 - [ ] Created/updated tests (and run them locally) **N/A**
 - [ ] Updated `requirements.txt` if a new package was installed **N/A**
