### PR TITLE
Replace description-file with description_file in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 license_files = LICENSE.txt


### PR DESCRIPTION
Fixes #
**Changes made in this Pull Request:**

Replace deprecated `description-file` with `description_file` in `setup.cfg`.

--- 
Before creating the PR, have you ... ?:
 - [ ] Created/updated docs **N/A**
 - [ ] Created/updated tests (and run them locally) **N/A**
 - [ ] Updated `requirements.txt` if a new package was installed **N/A**

----

Fixes:

```
/usr/lib/python3.12/site-packages/setuptools/dist.py:755: SetuptoolsDeprecationWarning: Invalid dash-separated options
  !!

          ********************************************************************************
          Usage of dash-separated 'description-file' will not be supported in future
          versions. Please use the underscore name 'description_file' instead.

          By 2023-Sep-26, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
          ********************************************************************************

  !!
    opt = self.warn_dash_deprecation(opt, section)
```
